### PR TITLE
Feature: Make list title and tasks editable

### DIFF
--- a/js/add-list.js
+++ b/js/add-list.js
@@ -7,7 +7,7 @@
 
 // DOM ACCESS VARIABLES - unique to add-list.html
 var buttonElement = document.getElementById('add-list');
-var inputElement = document.getElementById('new-title');
+var listTitleInputElement = document.getElementById('new-title');
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // FUNCTION DECLARATIONS
@@ -16,7 +16,7 @@ var inputElement = document.getElementById('new-title');
 // BUTTON CLICK EVENT HANDLER
 function handleNewList(event) {
   event.preventDefault();
-  var listTitle = inputElement.value;   // get what the user typed for 'list name'
+  var listTitle = listTitleInputElement.value;   // get what the user typed for 'list name'
   console.log(listTitle);
   new List(listTitle, []);              // create a new List (pushes to List.allLists array) with the user input and start an empty array of Tasks
   saveListsToLocalStorage();            // save all Lists to local storage

--- a/js/add-list.js
+++ b/js/add-list.js
@@ -17,7 +17,6 @@ var listTitleInputElement = document.getElementById('new-title');
 function handleNewList(event) {
   event.preventDefault();
   var listTitle = listTitleInputElement.value;   // get what the user typed for 'list name'
-  console.log(listTitle);
   new List(listTitle, []);              // create a new List (pushes to List.allLists array) with the user input and start an empty array of Tasks
   saveListsToLocalStorage();            // save all Lists to local storage
   window.location.href = 'lists.html';  // redirect to lists.html

--- a/js/app.js
+++ b/js/app.js
@@ -29,7 +29,6 @@ List.prototype.renderTasks = function () {
   completeUlElement.innerHTML = '';
   // Loop through the tasks of a list
   for (var i = 0; i < this.taskList.length; i++) {
-    console.log(this.taskList[i]);
     var newLi = this.taskList[i].createLi();      // create a li for each task 
     if (this.taskList[i].checked === false) {     // if the task isn't checked, append the 'incomplete' ul
       incompleteUlElement.appendChild(newLi);
@@ -68,7 +67,7 @@ Task.prototype.createLi = function () {
   }
   textInputElement.type = 'text';
   textInputElement.value = this.userText; // Puts user input into textInput element
-  textInputElement.readOnly = true;       // Makes textInput element uneditable
+  textInputElement.disabled = true;       // Makes textInput element uneditable
   deleteButtonElement.innerHTML = '';     // no text inside the button
   // Append the HTML elements in order
   labelElement.appendChild(inputElement);       // puts the input inside the label

--- a/js/lists.js
+++ b/js/lists.js
@@ -7,6 +7,7 @@
 // DOM ACCESS VARIABLES - unique to lists.html
 var h1Element = document.getElementById('list-name');
 var textInputElement = document.getElementById('text-input');
+var listTitleInputElement = document.getElementById('list-name-input');
 var addTaskButtonElement = document.getElementById('add-task');
 var incompleteUlElement = document.getElementById('incomplete-list');
 var completeUlElement = document.getElementById('complete-list');
@@ -18,22 +19,16 @@ var completeUlElement = document.getElementById('complete-list');
 // RENDER ON PAGE LOAD
 function renderOnPageLoad() {
   getListsFromLocalStorage();     // declared in app.js
-
   renderListName();               // declared below
-
   List.allLists[0].renderTasks(); // invokes list method that clears page and renders all tasks as li's
 }
 
 // RENDER LIST TITLE
 function renderListName() {
-  // h1Element.innerHTML = '';
-  var inputElement = document.createElement('input');
-  inputElement.type = 'text';
-  inputElement.value = List.allLists[0].listTitle
-  inputElement.readOnly = true;
-
-  h1Element.appendChild(inputElement);
-  // h1Element.textContent = List.allLists[0].listTitle;
+  listTitleInputElement.value = '';
+  listTitleInputElement.value = List.allLists[0].listTitle;
+  listTitleInputElement.readOnly = true;
+  h1Element.appendChild(listTitleInputElement);
 }
 
 // EVENT HANDLER FOR 'ADD TASK' BUTTON CLICK
@@ -97,9 +92,27 @@ function handleCheckboxChange(event) {
 // 'ADD TASK' BUTTON CLICK EVENT LISTENER
 addTaskButtonElement.addEventListener('click', handleAddTask);
 
+
+// HANDLES DOUBLE-CLICKING A LIST TITLE
+function handleEditListTitle() {
+  event.target.readOnly = false;
+  console.log(event);
+
+}
+
+function handleListTitleBlur() {
+  console.log(event.target);
+  console.log(event);
+}
+
+
 // 'CHECK TASK' EVENT LISTENERS
 incompleteUlElement.addEventListener('change', handleCheckboxChange); // listens for checkbox change in 'incomplete' ul
 completeUlElement.addEventListener('change', handleCheckboxChange); // listens for checkbox change in 'complete' ul
+
+// 'EDIT TITLE' EVENT LISTENERS
+h1Element.addEventListener('dblclick', handleEditListTitle);
+h1Element.addEventListener('blur', handleListTitleBlur);
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // FUNCTION INVOCATIONS

--- a/js/lists.js
+++ b/js/lists.js
@@ -1,8 +1,8 @@
 'use strict';
 
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// +++++++++++++++++++++++++++++++++++++++++++++
 // DATA
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// +++++++++++++++++++++++++++++++++++++++++++++
 
 // DOM ACCESS VARIABLES - unique to lists.html
 var h1Element = document.getElementById('list-name');
@@ -12,9 +12,9 @@ var addTaskButtonElement = document.getElementById('add-task');
 var incompleteUlElement = document.getElementById('incomplete-list');
 var completeUlElement = document.getElementById('complete-list');
 
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// +++++++++++++++++++++++++++++++++++++++++++++
 // FUNCTION DECLARATIONS
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// +++++++++++++++++++++++++++++++++++++++++++++
 
 // RENDER ON PAGE LOAD
 function renderOnPageLoad() {
@@ -94,15 +94,44 @@ addTaskButtonElement.addEventListener('click', handleAddTask);
 
 
 // HANDLES DOUBLE-CLICKING A LIST TITLE
-function handleEditListTitle() {
+function handleEditListTitle(event) {
   event.target.disabled = false; // Makes the list title editable
 }
 
 // HANDLES CLICKING AWAY FROM LIST TITLE
-function handleListTitleBlur() {
-  event.target.disabled = true;                 // Makes the list title un-editable
+function handleListTitleBlur(event) {
+  event.target.disabled = true;                 // Makes the list title uneditable
   var editedListTitle = event.target.value;     // Grabs the new list title from the page
   List.allLists[0].listTitle = editedListTitle; // Changes the list title object to match the page
+  removeListsFromLocalStorage();
+  saveListsToLocalStorage();
+  renderOnPageLoad();
+}
+
+// HANDLES DOUBLE-CLICKING A TASK
+var lastEditedTaskValue;                      // Variable to store the input value when a task is clicked into
+var lastEditedTaskInputElement;               // Variable to store the input element clicked into
+function handleEditTask(event) {
+  lastEditedTaskValue = event.target.value;   // Assigns value to variables above
+  lastEditedTaskInputElement = event.target;
+  event.target.disabled = false;              // Makes the task editable
+  lastEditedTaskInputElement.addEventListener('blur', handleEditTaskBlur);  // Starts listening for blur of current task (focused off of)
+}
+
+// HANDLES CLICKING AWAY FROM EDITED TASK
+function handleEditTaskBlur(event) {
+  event.target.disabled = true;
+  var newEditedTaskValue = event.target.value;                             // Grabs the new task content from the page
+  if (lastEditedTaskValue !== newEditedTaskValue) {                        // Runs the rest of the function only if task value changed
+    console.log('content changed');
+    for (var i = 0; i < List.allLists[0].taskList.length; i++) {           // Loops through all the tasks
+      if (List.allLists[0].taskList[i].userText === lastEditedTaskValue) { // Finds the targeted task
+        List.allLists[0].taskList[i].userText = newEditedTaskValue;        // Changes the task object's userText to the new value
+        break;
+      }
+    }      
+  }
+  lastEditedTaskInputElement.removeEventListener('blur', handleEditTaskBlur); // Stops listening for blur of current task
   removeListsFromLocalStorage();
   saveListsToLocalStorage();
   renderOnPageLoad();
@@ -116,8 +145,11 @@ completeUlElement.addEventListener('change', handleCheckboxChange);   // listens
 h1Element.addEventListener('dblclick', handleEditListTitle);          // Fires handler when the list title is double-clicked
 listTitleInputElement.addEventListener('blur', handleListTitleBlur);  // Fires handler when the list title input is blurred (focused off of)
 
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// 'EDIT TASK' EVENT LISTENER
+incompleteUlElement.addEventListener('dblclick', handleEditTask); // Listens for double-click in 'incomplete' ul
+
+// +++++++++++++++++++++++++++++++++++++++++++++
 // FUNCTION INVOCATIONS
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// +++++++++++++++++++++++++++++++++++++++++++++
 
 renderOnPageLoad();

--- a/js/lists.js
+++ b/js/lists.js
@@ -26,7 +26,14 @@ function renderOnPageLoad() {
 
 // RENDER LIST TITLE
 function renderListName() {
-  h1Element.textContent = List.allLists[0].listTitle;
+  // h1Element.innerHTML = '';
+  var inputElement = document.createElement('input');
+  inputElement.type = 'text';
+  inputElement.value = List.allLists[0].listTitle
+  inputElement.readOnly = true;
+
+  h1Element.appendChild(inputElement);
+  // h1Element.textContent = List.allLists[0].listTitle;
 }
 
 // EVENT HANDLER FOR 'ADD TASK' BUTTON CLICK

--- a/js/lists.js
+++ b/js/lists.js
@@ -6,8 +6,8 @@
 
 // DOM ACCESS VARIABLES - unique to lists.html
 var h1Element = document.getElementById('list-name');
-var textInputElement = document.getElementById('text-input');
 var listTitleInputElement = document.getElementById('list-name-input');
+var textInputElement = document.getElementById('text-input');
 var addTaskButtonElement = document.getElementById('add-task');
 var incompleteUlElement = document.getElementById('incomplete-list');
 var completeUlElement = document.getElementById('complete-list');
@@ -27,7 +27,7 @@ function renderOnPageLoad() {
 function renderListName() {
   listTitleInputElement.value = '';
   listTitleInputElement.value = List.allLists[0].listTitle;
-  listTitleInputElement.readOnly = true;
+  listTitleInputElement.disabled = true;
   h1Element.appendChild(listTitleInputElement);
 }
 
@@ -95,24 +95,26 @@ addTaskButtonElement.addEventListener('click', handleAddTask);
 
 // HANDLES DOUBLE-CLICKING A LIST TITLE
 function handleEditListTitle() {
-  event.target.readOnly = false;
-  console.log(event);
-
+  event.target.disabled = false; // Makes the list title editable
 }
 
+// HANDLES CLICKING AWAY FROM LIST TITLE
 function handleListTitleBlur() {
-  console.log(event.target);
-  console.log(event);
+  event.target.disabled = true;                 // Makes the list title un-editable
+  var editedListTitle = event.target.value;     // Grabs the new list title from the page
+  List.allLists[0].listTitle = editedListTitle; // Changes the list title object to match the page
+  removeListsFromLocalStorage();
+  saveListsToLocalStorage();
+  renderOnPageLoad();
 }
-
 
 // 'CHECK TASK' EVENT LISTENERS
 incompleteUlElement.addEventListener('change', handleCheckboxChange); // listens for checkbox change in 'incomplete' ul
-completeUlElement.addEventListener('change', handleCheckboxChange); // listens for checkbox change in 'complete' ul
+completeUlElement.addEventListener('change', handleCheckboxChange);   // listens for checkbox change in 'complete' ul
 
 // 'EDIT TITLE' EVENT LISTENERS
-h1Element.addEventListener('dblclick', handleEditListTitle);
-h1Element.addEventListener('blur', handleListTitleBlur);
+h1Element.addEventListener('dblclick', handleEditListTitle);          // Fires handler when the list title is double-clicked
+listTitleInputElement.addEventListener('blur', handleListTitleBlur);  // Fires handler when the list title input is blurred (focused off of)
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // FUNCTION INVOCATIONS

--- a/lists.html
+++ b/lists.html
@@ -10,7 +10,7 @@
     </header>
 
     <a id="" href="index.html" title=""></a>
-    <h1 id="list-name"></h1>
+    <h1 id="list-name"><input id="list-name-input" type="text" /></h1>
     <form>
         <input id="text-input" type="" />
         <button id="add-task"></button>


### PR DESCRIPTION
Billy & Andrew worked on this together using VSCode LiveShare. Commits made by Billy, as he started the session, but all edits made by both in real time. 
This feature makes it possible to double click on the list title and change it, click away and have it saved in local storage. 
This feature also makes this possible for each task. Double click to edit, bur (click away/un-focus) to save changes to the page and local storage.